### PR TITLE
adjust test naming convention

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,28 +77,19 @@ func TestGetFirstContributionYearByUsername(t *testing.T) {
 
 ```go
 // function to test
-func GetContributionsByUsername() {
+func (g *GithubService) GetContributionsByUsername() {
     // logic
 }
 
 // notice the naming for the main test for GetContributionsByUsername
-func TestGetContributionsByUsername(t *testing.T) {
+// the struct followed but a single underscore and the receiver method name
+func TestGithubService_GetContributionsByUsername(t *testing.T) {
     // test
 }
 
-// test modifiers have a single underscore followed by what you are testing for
-func TestGetContributionsByUsername_MultiYear(t *testing.T) {
+// test modifiers are separated by a double underscore followed by what you are testing for
+func TestGithubService_GetContributionsByUsername__MultiYear(t *testing.T) {
     // test
-}
-
-// use double underscore for methods on structs
-func TestLongestContributionStreak__String(t *testing.T) {
-
-}
-\
-// modifier on a struct method would be followed by a final underscore and what you are testing for
-func TestLongestContributionStreak__String_NoStreak(t *testing.T) {
-
 }
 
 ```

--- a/internal/github/contributions_test.go
+++ b/internal/github/contributions_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/mock"
 )
 
-func TestGetContributionsByUsername(t *testing.T) {
+func TestGithubService_GetContributionsByUsername(t *testing.T) {
 	assert := assert.New(t)
 	githubClient := &MockGithubClient{}
 	githubService := NewGithubService(githubClient)
@@ -84,7 +84,7 @@ func TestGetContributionsByUsername(t *testing.T) {
 	githubClient.AssertExpectations(t)
 }
 
-func TestGetContributionsByUsername_MultiYear(t *testing.T) {
+func TestGithubService_GetContributionsByUsername__MultiYear(t *testing.T) {
 	assert := assert.New(t)
 	githubClient := &MockGithubClient{}
 	githubService := NewGithubService(githubClient)
@@ -181,7 +181,7 @@ func TestGetContributionsByUsername_MultiYear(t *testing.T) {
 	githubClient.AssertExpectations(t)
 }
 
-func TestGetContributionsByUsername_DatesZeroValue(t *testing.T) {
+func TestGithubService_GetContributionsByUsername__DatesZeroValue(t *testing.T) {
 	assert := assert.New(t)
 	githubClient := &MockGithubClient{}
 	githubService := NewGithubService(githubClient)
@@ -253,13 +253,13 @@ func TestGetContributionsByUsername_DatesZeroValue(t *testing.T) {
 // labels: tests, good first issue
 // Need to run a table test on GetContributionsByUsername to hit
 // ErrMissingUsername and ErrToDateBeforeFromDate
-func TestGetContributionsByUsername_Errors(t *testing.T) {
+func TestGithubService_GetContributionsByUsername__Errors(t *testing.T) {
 
 }
 
 // TODO Tests: GetFirstContributionYearByUsername
 // labels: tests, good first issue
-func TestGetFirstContributionYearByUsername(t *testing.T) {
+func TestGithubService_GetFirstContributionYearByUsername(t *testing.T) {
 
 }
 
@@ -269,9 +269,15 @@ func TestCurrentContributionStreak_String(t *testing.T) {
 
 }
 
+// TODO Tests: CurrentContributionStreak.String() no streak
+// labels: tests
+func TestCurrentContributionStreak_String__NoStreak(t *testing.T) {
+
+}
+
 // TODO Tests: GetCurrentContributionStreakByUsername
 // labels: tests
-func TestGetCurrentContributionStreakByUsername(t *testing.T) {
+func TestGithubService_GetCurrentContributionStreakByUsername(t *testing.T) {
 
 }
 
@@ -283,7 +289,7 @@ func TestLongestContributionStreak_String(t *testing.T) {
 
 // TODO Tests: GetLongestContributionStreakByUsername
 // labels: tests
-func TestGetLongestContributionStreakByUsername(t *testing.T) {
+func TestGithubService_GetLongestContributionStreakByUsername(t *testing.T) {
 
 }
 
@@ -295,6 +301,6 @@ func TestTotalContribution_String(t *testing.T) {
 
 // TODO Tests: GetTotalContributionsByUsername
 // labels: tests, good first issue
-func TestGetTotalContributionsByUsername(t *testing.T) {
+func TestGithubService_GetTotalContributionsByUsername(t *testing.T) {
 
 }


### PR DESCRIPTION
Naming convention to use:
`Test{ReceiverStructName}_{ReceiverMethodName}__{ModifierDescription}`

Always specify the receiver struct name and receiver method name separated by a single underscore. This will appear more often than the modifiers, so modifiers should be separated by double underscores.