### PR TITLE
GetTotalContributionsByUsername test

### DIFF
--- a/internal/github/contributions_test.go
+++ b/internal/github/contributions_test.go
@@ -562,8 +562,63 @@ func TestTotalContribution_String(t *testing.T) {
 
 }
 
-// TODO Tests: GetTotalContributionsByUsername
-// labels: tests, good first issue
 func TestGithubService_GetTotalContributionsByUsername(t *testing.T) {
+	assert := assert.New(t)
+	githubClient := &MockGithubClient{}
+	githubService := NewGithubService(githubClient)
 
+	ctx := context.Background()
+
+	username := "devy"
+	to := time.Now()
+
+	githubClient.On(
+		"Query",
+		ctx,
+		mock.AnythingOfType("*github.contributionYears"),
+		mock.MatchedBy(func(params map[string]interface{}) bool {
+			return githubv4.String(username) == params["username"]
+		}),
+	).Return(nil).Run(func(args mock.Arguments) {
+		a := args.Get(1).(*contributionYears)
+		(*a) = contributionYears{
+			User: userContributionYears{
+				ContributionsCollection: contributionsCollectionContributionYears{
+					ContributionYears: []int{
+						to.Year(),
+					},
+				},
+			},
+		}
+	}).Once()
+
+	year := time.Date(to.Year(), 1, 1, 0, 0, 0, 0, time.UTC)
+
+	githubClient.On(
+		"Query",
+		ctx,
+		mock.AnythingOfType("*github.contributionsQuery"),
+		mock.MatchedBy(func(params map[string]interface{}) bool {
+			assert.WithinDuration(year, params["from"].(githubv4.DateTime).Time, time.Millisecond)
+			assert.WithinDuration(time.Now(), params["to"].(githubv4.DateTime).Time, time.Millisecond)
+			return githubv4.String(username) == params["username"]
+		}),
+	).Return(nil).Run(func(args mock.Arguments) {
+		a := args.Get(1).(*contributionsQuery)
+		(*a) = contributionsQuery{
+			User: user{
+				ContributionsCollection: contributionsCollection{
+					ContributionCalendar: contributionCalendar{
+						TotalContributions: 1000,
+					},
+				},
+			},
+		}
+	}).Once()
+
+	resp, err := githubService.GetTotalContributionsByUsername(ctx, username)
+
+	assert.NoError(err)
+	assert.Equal(resp.String(), "total github contributions: 1000")
+	assert.Equal(resp.Total, 1000)
 }

--- a/internal/github/contributions_test.go
+++ b/internal/github/contributions_test.go
@@ -556,12 +556,6 @@ func TestGithubService_GetLongestContributionStreakByUsername__NoContributionDay
 	assert.Equal(0, resp.Streak)
 }
 
-// TODO Tests: TotalContribution.String()
-// labels: tests, good first issue
-func TestTotalContribution_String(t *testing.T) {
-
-}
-
 func TestGithubService_GetTotalContributionsByUsername(t *testing.T) {
 	assert := assert.New(t)
 	githubClient := &MockGithubClient{}


### PR DESCRIPTION
Test for GetTotalContributionsByUsername

I think I might have accidently closed the original issue for this test.

This also closes 37 since it is testing the string output.

Closes #37